### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/code_examples/genomics-master/gsa.Rmd
+++ b/code_examples/genomics-master/gsa.Rmd
@@ -243,7 +243,7 @@ t_N)' (1 \dots 1)')) \\\\
 \end{eqnarray}
 $$
 
-Note that when $\rho$ is positive, the variance is inflated by $\{1 + (N-1) \rho N\}$. Although in general we don't expect all the $\rho$ to be the same within a gene set, a correction factor can still be computed for each gene set that depends on the average $\rho$ in the gene set. The formula can been seen on page 295 [here] (http://dx.doi.org/10.1214/07-AOAS146). The formula for the correction for the Wald statistic is also included. 
+Note that when $\rho$ is positive, the variance is inflated by $\{1 + (N-1) \rho N\}$. Although in general we don't expect all the $\rho$ to be the same within a gene set, a correction factor can still be computed for each gene set that depends on the average $\rho$ in the gene set. The formula can been seen on page 295 [here] (https://doi.org/10.1214/07-AOAS146). The formula for the correction for the Wald statistic is also included. 
 
 These correction factor can be used to adapt the simple summary statistics described above. In fact, several methods have been published that are based on the simple mean shift approach but take correlation into account to develop summary statistics and statistical inference based on asymptotic approximations [ROAST](http://www.ncbi.nlm.nih.gov/pubmed/?term=20610611), [CAMERA](http://www.ncbi.nlm.nih.gov/pubmed/22638577). In the computer labs we will demonstrate one of these pieces of software. For simplicity, here we
 create approximation based on $\sqrt{N} \bar{t}$ and use the correction factor. Here compare the original $\sqrt{N} \bar{t}$ to the corrected version:

--- a/code_examples/genomics-master/normalization.Rmd
+++ b/code_examples/genomics-master/normalization.Rmd
@@ -508,7 +508,7 @@ Wolfgang Huber, Anja von Heydebreck, Holger Sültmann, Annemarie Poustka and Mar
 
 B.P. Durbin, J.S. Hardin, D.M. Hawkins and D.M. Rocke, "A variance-stabilizing transformation for gene-expression microarray data", Bioinformatics. 2002. <http://bioinformatics.oxfordjournals.org/content/18/suppl_1/S105>
 
-Wolfgang Huber, Anja von Heydebreck, Holger Sueltmann, Annemarie Poustka, Martin Vingron, "Parameter estimation for the calibration and variance stabilization of microarray data" Stat Appl Mol Biol Genet, 2003. <http://dx.doi.org/10.2202/1544-6115.1008>
+Wolfgang Huber, Anja von Heydebreck, Holger Sueltmann, Annemarie Poustka, Martin Vingron, "Parameter estimation for the calibration and variance stabilization of microarray data" Stat Appl Mol Biol Genet, 2003. <https://doi.org/10.2202/1544-6115.1008>
 
 For NGS read counts:
 

--- a/code_examples/genomics-master/read_counting.Rmd
+++ b/code_examples/genomics-master/read_counting.Rmd
@@ -136,7 +136,7 @@ Command line tools:
 
 Simon Anders, Paul Theodor Pyl, Wolfgang Huber.
 HTSeq — A Python framework to work with high-throughput sequencing data
-bioRxiv preprint (2014), doi: [10.1101/002824](http://dx.doi.org/10.1101/002824)
+bioRxiv preprint (2014), doi: [10.1101/002824](https://doi.org/10.1101/002824)
 
 <http://www-huber.embl.de/users/anders/HTSeq/doc/count.html>
 


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update all static DOI links.

Cheers!